### PR TITLE
refactor: migrate member ID handling from String to UUID for improved…

### DIFF
--- a/application/src/main/java/com/callv2/member/application/member/activation/DefaultTogleMemberActivationUseCase.java
+++ b/application/src/main/java/com/callv2/member/application/member/activation/DefaultTogleMemberActivationUseCase.java
@@ -26,7 +26,7 @@ public class DefaultTogleMemberActivationUseCase extends TogleMemberActivationUs
 
         final Member member = memberGateway
                 .findById(MemberID.of(input.memberId()))
-                .orElseThrow(() -> NotFoundException.with(Member.class, input.memberId()));
+                .orElseThrow(() -> NotFoundException.with(Member.class, input.memberId().toString()));
 
         if (input.active())
             member.activate();

--- a/application/src/main/java/com/callv2/member/application/member/activation/TogleMemberActivationInput.java
+++ b/application/src/main/java/com/callv2/member/application/member/activation/TogleMemberActivationInput.java
@@ -1,8 +1,10 @@
 package com.callv2.member.application.member.activation;
 
-public record TogleMemberActivationInput(String memberId, Boolean active) {
+import java.util.UUID;
 
-    public static TogleMemberActivationInput of(String memberId, Boolean active) {
+public record TogleMemberActivationInput(UUID memberId, Boolean active) {
+
+    public static TogleMemberActivationInput of(UUID memberId, Boolean active) {
         return new TogleMemberActivationInput(memberId, active);
     }
 

--- a/application/src/main/java/com/callv2/member/application/member/create/CreateMemberOutput.java
+++ b/application/src/main/java/com/callv2/member/application/member/create/CreateMemberOutput.java
@@ -1,8 +1,10 @@
 package com.callv2.member.application.member.create;
 
-public record CreateMemberOutput(String id) {
+import java.util.UUID;
 
-    public static CreateMemberOutput with(String id) {
+public record CreateMemberOutput(UUID id) {
+
+    public static CreateMemberOutput with(UUID id) {
         return new CreateMemberOutput(id);
     }
 

--- a/application/src/main/java/com/callv2/member/application/member/retrieve/get/DefaultGetMemberUseCase.java
+++ b/application/src/main/java/com/callv2/member/application/member/retrieve/get/DefaultGetMemberUseCase.java
@@ -20,7 +20,7 @@ public class DefaultGetMemberUseCase extends GetMemberUseCase {
         return memberGateway
                 .findById(MemberID.of(input.id()))
                 .map(GetMemberOutput::from)
-                .orElseThrow(() -> NotFoundException.with(Member.class, input.id()));
+                .orElseThrow(() -> NotFoundException.with(Member.class, input.id().toString()));
     }
 
 }

--- a/application/src/main/java/com/callv2/member/application/member/retrieve/get/GetMemberInput.java
+++ b/application/src/main/java/com/callv2/member/application/member/retrieve/get/GetMemberInput.java
@@ -1,8 +1,10 @@
 package com.callv2.member.application.member.retrieve.get;
 
-public record GetMemberInput(String id) {
+import java.util.UUID;
 
-    public static GetMemberInput from(String id) {
+public record GetMemberInput(UUID id) {
+
+    public static GetMemberInput from(UUID id) {
         return new GetMemberInput(id);
     }
 

--- a/application/src/main/java/com/callv2/member/application/member/retrieve/get/GetMemberOutput.java
+++ b/application/src/main/java/com/callv2/member/application/member/retrieve/get/GetMemberOutput.java
@@ -2,12 +2,13 @@ package com.callv2.member.application.member.retrieve.get;
 
 import java.time.Instant;
 import java.util.Set;
+import java.util.UUID;
 
 import com.callv2.member.domain.member.entity.Member;
 import com.callv2.member.domain.member.valueobject.System;
 
 public record GetMemberOutput(
-        String id,
+        UUID id,
         String username,
         String email,
         String nickname,

--- a/application/src/main/java/com/callv2/member/application/member/retrieve/list/MemberListOutput.java
+++ b/application/src/main/java/com/callv2/member/application/member/retrieve/list/MemberListOutput.java
@@ -1,11 +1,12 @@
 package com.callv2.member.application.member.retrieve.list;
 
 import java.time.Instant;
+import java.util.UUID;
 
 import com.callv2.member.domain.member.entity.Member;
 
 public record MemberListOutput(
-        String id,
+        UUID id,
         String username,
         String email,
         String nickname,

--- a/application/src/main/java/com/callv2/member/application/member/update/system/DefaultUpdateMemberSystemAccessUseCase.java
+++ b/application/src/main/java/com/callv2/member/application/member/update/system/DefaultUpdateMemberSystemAccessUseCase.java
@@ -26,7 +26,7 @@ public class DefaultUpdateMemberSystemAccessUseCase extends UpdateMemberSystemAc
 
         final Member member = memberGateway
                 .findById(MemberID.of(input.memberId()))
-                .orElseThrow(() -> NotFoundException.with(Member.class, input.memberId()));
+                .orElseThrow(() -> NotFoundException.with(Member.class, input.memberId().toString()));
 
         eventDispatcher.notify(memberGateway.update(member.updateAvailableSystems(input.systems())));
     }

--- a/application/src/main/java/com/callv2/member/application/member/update/system/UpdateMemberSystemAccessInput.java
+++ b/application/src/main/java/com/callv2/member/application/member/update/system/UpdateMemberSystemAccessInput.java
@@ -1,12 +1,13 @@
 package com.callv2.member.application.member.update.system;
 
 import java.util.Set;
+import java.util.UUID;
 
 import com.callv2.member.domain.member.valueobject.System;
 
-public record UpdateMemberSystemAccessInput(String memberId, Set<System> systems) {
+public record UpdateMemberSystemAccessInput(UUID memberId, Set<System> systems) {
 
-    public static UpdateMemberSystemAccessInput of(final String memberId, final Set<System> systems) {
+    public static UpdateMemberSystemAccessInput of(final UUID memberId, final Set<System> systems) {
         return new UpdateMemberSystemAccessInput(memberId, systems);
     }
 

--- a/application/src/test/java/com/callv2/member/application/member/activation/DefaultTogleMemberActivationUseCaseTest.java
+++ b/application/src/test/java/com/callv2/member/application/member/activation/DefaultTogleMemberActivationUseCaseTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -47,7 +48,7 @@ public class DefaultTogleMemberActivationUseCaseTest {
     @Test
     void givenAnActiveTrueInput_whenCallsExecute_thenShouldActivateMember() {
 
-        final var expectedIdValue = "123";
+        final var expectedIdValue = UUID.randomUUID();
         final var expectedIsActive = true;
 
         final var expectedMemberId = MemberID.of(expectedIdValue);
@@ -113,7 +114,7 @@ public class DefaultTogleMemberActivationUseCaseTest {
     @Test
     void givenAnActiveFalseInput_whenCallsExecute_thenShouldDeactivateMember() {
 
-        final var expectedIdValue = "123";
+        final var expectedIdValue = UUID.randomUUID();
         final var expectedIsActive = false;
 
         final var expectedMemberId = MemberID.of(expectedIdValue);
@@ -179,14 +180,14 @@ public class DefaultTogleMemberActivationUseCaseTest {
     @Test
     void givenAnNonExistentMemberId_whenCallsExecute_thenShouldThrowsNotFoundException() {
 
-        final var expectedIdValue = "123";
+        final var expectedIdValue = UUID.randomUUID();
         final var expectedIsActive = false;
 
         final var expectedMemberId = MemberID.of(expectedIdValue);
 
-        final var expectedExceptionMessage = "Member with id '123' not found";
+        final var expectedExceptionMessage = "Member with id '%s' not found".formatted(expectedIdValue);
         final var expectedErrorCount = 1;
-        final var expectedErrorMessage = "Member with id '123' not found";
+        final var expectedErrorMessage = "Member with id '%s' not found".formatted(expectedIdValue);
 
         final var input = TogleMemberActivationInput.of(expectedIdValue, expectedIsActive);
 

--- a/application/src/test/java/com/callv2/member/application/member/create/DefaultCreateMemberUseCaseTest.java
+++ b/application/src/test/java/com/callv2/member/application/member/create/DefaultCreateMemberUseCaseTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 
 import java.time.Instant;
 import java.util.Set;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -62,7 +63,7 @@ public class DefaultCreateMemberUseCaseTest {
                 expectedEmail,
                 expectedPassword);
 
-        final var expectedMemberId = MemberID.of("123");
+        final var expectedMemberId = MemberID.of(UUID.randomUUID());
         final var expectedIsActive = false;
         final var expectedAvailableSystems = Set.<System>of();
         final var expectedCreateAt = Instant.now();

--- a/application/src/test/java/com/callv2/member/application/member/retrieve/get/DefaultGetMemberUseCaseTest.java
+++ b/application/src/test/java/com/callv2/member/application/member/retrieve/get/DefaultGetMemberUseCaseTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,7 +41,7 @@ public class DefaultGetMemberUseCaseTest {
     @Test
     void givenAnExistentMemberId_whenCallsExecute_thenShouldReturnMember() {
 
-        final var expectedIdValue = "123";
+        final var expectedIdValue = UUID.randomUUID();
         final var expectedMemberId = MemberID.of(expectedIdValue);
         final var expectedUsername = Username.of("username");
         final var expectedEmail = Email.of("email@eail.com");
@@ -83,12 +84,12 @@ public class DefaultGetMemberUseCaseTest {
     @Test
     void givenAnNonExistentMemberId_whenCallsExecute_thenShouldThorwsNotFoundException() {
 
-        final var expectedIdValue = "123";
+        final var expectedIdValue = UUID.randomUUID();
         final var expectedMemberId = MemberID.of(expectedIdValue);
 
-        final var expectedExceptionMessage = "Member with id '123' not found";
+        final var expectedExceptionMessage = "Member with id '%s' not found".formatted(expectedIdValue);
         final var expectedErrorCount = 1;
-        final var expectedErrorMessage = "Member with id '123' not found";
+        final var expectedErrorMessage = "Member with id '%s' not found".formatted(expectedIdValue);
 
         when(memberGateway.findById(eq(expectedMemberId)))
                 .thenReturn(Optional.empty());

--- a/application/src/test/java/com/callv2/member/application/member/retrieve/list/DefaultListMembersUseCaseTest.java
+++ b/application/src/test/java/com/callv2/member/application/member/retrieve/list/DefaultListMembersUseCaseTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import java.time.Instant;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,7 +43,7 @@ public class DefaultListMembersUseCaseTest {
     void givenAValidSearchQuery_whenCallsExecute_thenShouldReturnMembers() {
 
         final var expectedMember1 = Member.with(
-                MemberID.of("1"),
+                MemberID.of(UUID.randomUUID()),
                 Username.of("user1"),
                 Email.of("email1@email.com"),
                 Nickname.of("nickname1"),
@@ -53,7 +54,7 @@ public class DefaultListMembersUseCaseTest {
                 0L);
 
         final var expectedMember2 = Member.with(
-                MemberID.of("2"),
+                MemberID.of(UUID.randomUUID()),
                 Username.of("user2"),
                 Email.of("email2@email.com"),
                 Nickname.of("nickname2"),

--- a/application/src/test/java/com/callv2/member/application/member/update/system/DefaultUpdateMemberSystemAccessUseCaseTest.java
+++ b/application/src/test/java/com/callv2/member/application/member/update/system/DefaultUpdateMemberSystemAccessUseCaseTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.when;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -51,7 +52,7 @@ public class DefaultUpdateMemberSystemAccessUseCaseTest {
     @Test
     void givenAValidParams_whenCallsExecute_thenShouldUpdateMemberSystemAccess() {
 
-        final var expectedId = "123";
+        final var expectedId = UUID.randomUUID();
         final var expectedSystems = Set.of(System.DRIVE, System.MEMBER);
 
         final var expectedMemberId = MemberID.of(expectedId);
@@ -112,11 +113,11 @@ public class DefaultUpdateMemberSystemAccessUseCaseTest {
     @Test
     void givenAnNonExistentMemberId_whenCallsExecute_thenShouldThrowsNotFoundException() {
 
-        final var expectedId = "123";
+        final var expectedId = UUID.randomUUID();
         final var expectedSystems = Set.of(System.DRIVE, System.MEMBER);
         final var expectedMemberId = MemberID.of(expectedId);
-        final var expectedExceptionMessage = "Member with id '123' not found";
-        final var expectedErrorMessage = "Member with id '123' not found";
+        final var expectedExceptionMessage = "Member with id '%s' not found".formatted(expectedId);
+        final var expectedErrorMessage = "Member with id '%s' not found".formatted(expectedId);
         final var expectedErrorCount = 1;
 
         when(memberGateway.findById(expectedMemberId))

--- a/domain/src/main/java/com/callv2/member/domain/member/entity/MemberID.java
+++ b/domain/src/main/java/com/callv2/member/domain/member/entity/MemberID.java
@@ -1,20 +1,26 @@
 package com.callv2.member.domain.member.entity;
 
+import java.util.UUID;
+
 import com.callv2.member.domain.Identifier;
 
-public class MemberID extends Identifier<String> {
+public class MemberID extends Identifier<UUID> {
 
-    public MemberID(String value) {
+    public MemberID(UUID value) {
         super(value);
     }
 
-    public static MemberID of(final String id) {
+    public static MemberID of(final UUID id) {
         return new MemberID(id);
+    }
+
+    public static MemberID of(final String id) {
+        return new MemberID(UUID.fromString(id));
     }
 
     @Override
     public String getStringValue() {
-        return this.id;
+        return this.id.toString();
     }
 
 }

--- a/domain/src/main/java/com/callv2/member/domain/member/event/MemberCreatedEvent.java
+++ b/domain/src/main/java/com/callv2/member/domain/member/event/MemberCreatedEvent.java
@@ -3,6 +3,7 @@ package com.callv2.member.domain.member.event;
 import java.io.Serializable;
 import java.time.Instant;
 import java.util.Set;
+import java.util.UUID;
 
 import com.callv2.member.domain.event.Event;
 import com.callv2.member.domain.event.EventEntity;
@@ -27,7 +28,7 @@ public class MemberCreatedEvent extends Event<MemberCreatedEvent.Data> {
     }
 
     public record Data(
-            String id,
+            UUID id,
             String username,
             String email,
             String nickname,

--- a/domain/src/main/java/com/callv2/member/domain/member/event/MemberUpdatedEvent.java
+++ b/domain/src/main/java/com/callv2/member/domain/member/event/MemberUpdatedEvent.java
@@ -3,6 +3,7 @@ package com.callv2.member.domain.member.event;
 import java.io.Serializable;
 import java.time.Instant;
 import java.util.Set;
+import java.util.UUID;
 
 import com.callv2.member.domain.event.Event;
 import com.callv2.member.domain.event.EventEntity;
@@ -27,7 +28,7 @@ public class MemberUpdatedEvent extends Event<MemberUpdatedEvent.Data> {
     }
 
     public record Data(
-            String id,
+            UUID id,
             String username,
             String email,
             String nickname,

--- a/domain/src/test/java/com/callv2/member/domain/member/entity/MemberTest.java
+++ b/domain/src/test/java/com/callv2/member/domain/member/entity/MemberTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
 import java.util.Set;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 
@@ -22,7 +23,7 @@ public class MemberTest {
     @Test
     void givenAValidParams_whenCallsCreate_thenShouldCreateAMember() {
 
-        final var expectedId = MemberID.of("123");
+        final var expectedId = MemberID.of(UUID.randomUUID());
         final var expectedUsername = Username.of("user");
         final var expectedEmail = Email.of("eser@email.com");
         final var expectedNickname = Nickname.of("user_nickname");
@@ -55,7 +56,7 @@ public class MemberTest {
     @Test
     void givenAMemberWithNoAvailableSystems_whenCallsUpdateAvailableSystem_thenShouldAddTheSystem() {
 
-        final var expectedId = MemberID.of("123");
+        final var expectedId = MemberID.of(UUID.randomUUID());
         final var expectedUsername = Username.of("user");
         final var expectedEmail = Email.of("email@email.com");
         final var expectedNickname = Nickname.of("user_nickname");
@@ -97,7 +98,7 @@ public class MemberTest {
     @Test
     void givenAnAlreadyAvailableSystems_whenCallsUpdateAvailableSystem_thenShouldDoNothing() {
 
-        final var expectedId = MemberID.of("123");
+        final var expectedId = MemberID.of(UUID.randomUUID());
         final var expectedUsername = Username.of("user");
         final var expectedEmail = Email.of("email@email.com");
         final var expectedNickname = Nickname.of("user_nickname");
@@ -134,7 +135,7 @@ public class MemberTest {
     @Test
     void givenANullSystems_whenCallsUpdateAvailableSystem_thenShouldDoNothing() {
 
-        final var expectedId = MemberID.of("123");
+        final var expectedId = MemberID.of(UUID.randomUUID());
         final var expectedUsername = Username.of("user");
         final var expectedEmail = Email.of("email@email.com");
         final var expectedNickname = Nickname.of("user_nickname");
@@ -170,7 +171,7 @@ public class MemberTest {
     @Test
     void givenAEmptySystems_whenCallsUpdateAvailableSystems_thenShouldClearAvailableSystems() {
 
-        final var expectedId = MemberID.of("123");
+        final var expectedId = MemberID.of(UUID.randomUUID());
         final var expectedUsername = Username.of("user");
         final var expectedEmail = Email.of("email@email.com");
         final var expectedNickname = Nickname.of("user_nickname");
@@ -212,7 +213,7 @@ public class MemberTest {
     @Test
     void givenAnInactiveMember_whenCallsActivate_thenShouldActivateTheMember() {
 
-        final var expectedId = MemberID.of("123");
+        final var expectedId = MemberID.of(UUID.randomUUID());
         final var expectedUsername = Username.of("user");
         final var expectedEmail = Email.of("email@email.com");
         final var expectedNickname = Nickname.of("user_nickname");
@@ -253,7 +254,7 @@ public class MemberTest {
     @Test
     void givenAnActiveMember_whenCallsDeactivate_thenShouldInactivateTheMember() {
 
-        final var expectedId = MemberID.of("123");
+        final var expectedId = MemberID.of(UUID.randomUUID());
         final var expectedUsername = Username.of("user");
         final var expectedEmail = Email.of("email@email.com");
         final var expectedNickname = Nickname.of("user_nickname");
@@ -294,7 +295,7 @@ public class MemberTest {
     @Test
     void givenAnInactiveMember_whenCallsDeactivate_thenShouldDoNothing() {
 
-        final var expectedId = MemberID.of("123");
+        final var expectedId = MemberID.of(UUID.randomUUID());
         final var expectedUsername = Username.of("user");
         final var expectedEmail = Email.of("email@email.com");
         final var expectedNickname = Nickname.of("user_nickname");
@@ -331,7 +332,7 @@ public class MemberTest {
     @Test
     void givenAnActiveMember_whenCallsActivate_thenShouldDoNothing() {
 
-        final var expectedId = MemberID.of("123");
+        final var expectedId = MemberID.of(UUID.randomUUID());
         final var expectedUsername = Username.of("user");
         final var expectedEmail = Email.of("email@email.com");
         final var expectedNickname = Nickname.of("user_nickname");

--- a/infrastructure/src/main/java/com/callv2/member/infrastructure/api/MemberAdminAPI.java
+++ b/infrastructure/src/main/java/com/callv2/member/infrastructure/api/MemberAdminAPI.java
@@ -1,6 +1,7 @@
 package com.callv2.member.infrastructure.api;
 
 import java.util.List;
+import java.util.UUID;
 
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -38,7 +39,7 @@ public interface MemberAdminAPI {
             @ApiResponse(responseCode = "404", description = "Member not found")
     })
     ResponseEntity<Void> toggleActive(
-            @PathVariable(value = "id", required = true) String id,
+            @PathVariable(value = "id", required = true) UUID id,
             @RequestParam(value = "active", defaultValue = "true") boolean active);
 
     @PutMapping("{id}/systems")
@@ -48,7 +49,7 @@ public interface MemberAdminAPI {
             @ApiResponse(responseCode = "404", description = "Member not found")
     })
     ResponseEntity<Void> updateAvailableSystems(
-            @PathVariable(value = "id", required = true) String id,
+            @PathVariable(value = "id", required = true) UUID id,
             @RequestBody UpdateMemberSystemsRequest request);
 
     @GetMapping("{id}")
@@ -57,7 +58,7 @@ public interface MemberAdminAPI {
             @ApiResponse(responseCode = "200", description = "Member account found", content = @Content(schema = @Schema(implementation = GetMemberResponse.class))),
             @ApiResponse(responseCode = "404", description = "Member not found")
     })
-    ResponseEntity<GetMemberResponse> get(@PathVariable(value = "id", required = true) String id);
+    ResponseEntity<GetMemberResponse> get(@PathVariable(value = "id", required = true) UUID id);
 
     @GetMapping(produces = { MediaType.APPLICATION_JSON_VALUE })
     @Operation(summary = "List members", description = "This method list files", security = @SecurityRequirement(name = "bearerAuth"))

--- a/infrastructure/src/main/java/com/callv2/member/infrastructure/api/controller/MemberAdminController.java
+++ b/infrastructure/src/main/java/com/callv2/member/infrastructure/api/controller/MemberAdminController.java
@@ -1,6 +1,7 @@
 package com.callv2.member.infrastructure.api.controller;
 
 import java.util.List;
+import java.util.UUID;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -45,19 +46,19 @@ public class MemberAdminController implements MemberAdminAPI {
     }
 
     @Override
-    public ResponseEntity<Void> toggleActive(final String id, final boolean active) {
+    public ResponseEntity<Void> toggleActive(final UUID id, final boolean active) {
         togleMemberActivationUseCase.execute(TogleMemberActivationInput.of(id, active));
         return ResponseEntity.noContent().build();
     }
 
     @Override
-    public ResponseEntity<Void> updateAvailableSystems(String id, UpdateMemberSystemsRequest request) {
+    public ResponseEntity<Void> updateAvailableSystems(UUID id, UpdateMemberSystemsRequest request) {
         updateMemberSystemAccessUseCase.execute(UpdateMemberSystemAccessInput.of(id, request.systems()));
         return ResponseEntity.noContent().build();
     }
 
     @Override
-    public ResponseEntity<GetMemberResponse> get(String id) {
+    public ResponseEntity<GetMemberResponse> get(UUID id) {
         return ResponseEntity.ok(MemberPresenter.present(getMemberUseCase.execute(GetMemberInput.from(id))));
     }
 

--- a/infrastructure/src/main/java/com/callv2/member/infrastructure/member/DefaultMemberGateway.java
+++ b/infrastructure/src/main/java/com/callv2/member/infrastructure/member/DefaultMemberGateway.java
@@ -144,7 +144,7 @@ public class DefaultMemberGateway implements MemberGateway {
 
     private void performKeycloakUserDataUpdate(final Member member) {
         this.tokenKeycloakUserService
-                .updateUser(member.getId().getValue(), keycloakUserMapper.toUserRepresentation(member));
+                .updateUser(member.getId().getStringValue(), keycloakUserMapper.toUserRepresentation(member));
     }
 
     private boolean needsKeycloakUserGroupUpdate(final Member actualMember, final Member newMember) {
@@ -152,7 +152,7 @@ public class DefaultMemberGateway implements MemberGateway {
     }
 
     private void performKeycloakUserGroupUpdate(final Member member) {
-        final String userId = member.getId().getValue();
+        final String userId = member.getId().getStringValue();
         final Set<String> newUserGroupsPaths = this.keycloakGroupMapper.toGroupPaths(member.getAvailableSystems());
 
         final List<String> newUserGroupIds = newUserGroupsPaths

--- a/infrastructure/src/main/java/com/callv2/member/infrastructure/member/model/GetMemberResponse.java
+++ b/infrastructure/src/main/java/com/callv2/member/infrastructure/member/model/GetMemberResponse.java
@@ -2,11 +2,12 @@ package com.callv2.member.infrastructure.member.model;
 
 import java.time.Instant;
 import java.util.Set;
+import java.util.UUID;
 
 import com.callv2.member.domain.member.valueobject.System;
 
 public record GetMemberResponse(
-        String id,
+        UUID id,
         String username,
         String email,
         String nickname,

--- a/infrastructure/src/main/java/com/callv2/member/infrastructure/member/model/MemberListResponse.java
+++ b/infrastructure/src/main/java/com/callv2/member/infrastructure/member/model/MemberListResponse.java
@@ -1,9 +1,10 @@
 package com.callv2.member.infrastructure.member.model;
 
 import java.time.Instant;
+import java.util.UUID;
 
 public record MemberListResponse(
-        String id,
+        UUID id,
         String username,
         String email,
         String nickname,

--- a/infrastructure/src/main/java/com/callv2/member/infrastructure/member/persistence/MemberJpaEntity.java
+++ b/infrastructure/src/main/java/com/callv2/member/infrastructure/member/persistence/MemberJpaEntity.java
@@ -2,6 +2,7 @@ package com.callv2.member.infrastructure.member.persistence;
 
 import java.time.Instant;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import com.callv2.member.domain.member.entity.Member;
@@ -23,7 +24,7 @@ import jakarta.persistence.Table;
 public class MemberJpaEntity {
 
     @Id
-    private String id;
+    private UUID id;
 
     private String username;
 
@@ -45,7 +46,7 @@ public class MemberJpaEntity {
     private Long synchronizedVersion;
 
     public MemberJpaEntity(
-            final String id,
+            final UUID id,
             final String username,
             final String nickname,
             final String email,
@@ -99,11 +100,11 @@ public class MemberJpaEntity {
                 member.getSynchronizedVersion());
     }
 
-    public String getId() {
+    public UUID getId() {
         return id;
     }
 
-    public void setId(String id) {
+    public void setId(UUID id) {
         this.id = id;
     }
 

--- a/infrastructure/src/main/java/com/callv2/member/infrastructure/member/persistence/MemberJpaRepository.java
+++ b/infrastructure/src/main/java/com/callv2/member/infrastructure/member/persistence/MemberJpaRepository.java
@@ -1,11 +1,13 @@
 package com.callv2.member.infrastructure.member.persistence;
 
+import java.util.UUID;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberJpaRepository extends JpaRepository<MemberJpaEntity, String> {
+public interface MemberJpaRepository extends JpaRepository<MemberJpaEntity, UUID> {
 
     Page<MemberJpaEntity> findAll(Specification<MemberJpaEntity> whereClause, Pageable page);
 

--- a/infrastructure/src/test/java/com/callv2/member/infrastructure/member/DefaultMemberGatewayTest.java
+++ b/infrastructure/src/test/java/com/callv2/member/infrastructure/member/DefaultMemberGatewayTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -71,7 +72,8 @@ public class DefaultMemberGatewayTest {
     @Test
     void givenAValidPreMember_whenCallsCreate_thenShouldPersistMemberInKeycloakAndOwnDatabase() {
 
-        final var expectedMemberIdValue = "123";
+        final var expectedMemberIdValue = UUID.randomUUID().toString();
+        final var expectedMemberId = MemberID.of(expectedMemberIdValue);
         final var expectedUserName = Username.of("username");
         final var expectedEmail = Email.of("email@email.com");
         final var expectedNickname = Nickname.of(expectedUserName.value());
@@ -94,7 +96,7 @@ public class DefaultMemberGatewayTest {
 
         final var actualMember = assertDoesNotThrow(() -> gateway.create(preMember));
 
-        assertEquals(expectedMemberIdValue, actualMember.getId().getValue());
+        assertEquals(expectedMemberId, actualMember.getId());
         assertEquals(expectedUserName, actualMember.getUsername());
         assertEquals(expectedEmail, actualMember.getEmail());
         assertEquals(expectedNickname, actualMember.getNickname());
@@ -143,7 +145,7 @@ public class DefaultMemberGatewayTest {
     @Test
     void givenAValidPreMember_whenCallsCreateAndRepositorySaveThrowsARandomException_thenShouldNotPersistMemberInKeycloakAndOwnDatabase() {
 
-        final var expectedMemberIdValue = "123";
+        final var expectedMemberIdValue = UUID.randomUUID().toString();
         final var expectedUserName = Username.of("username");
         final var expectedEmail = Email.of("email@email.com");
         final var expectedPassword = Password.of("password");
@@ -183,7 +185,7 @@ public class DefaultMemberGatewayTest {
     @Test
     void givenAValidMember_whenCallsUpdate_thenShouldUpdateMemberInKeycloakAndOwnDatabase() {
 
-        final var expectedMemberId = MemberID.of("123");
+        final var expectedMemberId = MemberID.of(UUID.randomUUID());
         final var expectedUserName = Username.of("username");
         final var expectedEmail = Email.of("user@member.com");
         final var expectedNickname = Nickname.of("nickname");
@@ -255,7 +257,7 @@ public class DefaultMemberGatewayTest {
 
         doNothing()
                 .when(keycloakUserService)
-                .updateUser(eq(expectedMemberId.getValue()), any());
+                .updateUser(eq(expectedMemberId.getStringValue()), any());
 
         when(keycloakGroupService.getGroupByPath(eq(driveGroupPath)))
                 .thenReturn(drivegroupRepresentation);
@@ -263,12 +265,12 @@ public class DefaultMemberGatewayTest {
         when(keycloakGroupService.getGroupByPath(eq(memberGroupPath)))
                 .thenReturn(memberGroupRepresentation);
 
-        when(keycloakUserService.getGroups(eq(expectedMemberId.getValue())))
+        when(keycloakUserService.getGroups(eq(expectedMemberId.getStringValue())))
                 .thenReturn(List.of(memberGroupRepresentation));
 
         doNothing()
                 .when(keycloakUserService)
-                .addGroup(eq(expectedMemberId.getValue()), eq(driveGroupId));
+                .addGroup(eq(expectedMemberId.getStringValue()), eq(driveGroupId));
 
         final var actualUpdatedMember = gateway.update(updatedMember);
 
@@ -284,19 +286,19 @@ public class DefaultMemberGatewayTest {
         verify(memberJpaRepository, times(1)).findById(eq(expectedMemberId.getValue()));
         verify(memberJpaRepository, times(1)).findById(any());
 
-        verify(keycloakUserService, times(1)).updateUser(eq(expectedMemberId.getValue()), any());
+        verify(keycloakUserService, times(1)).updateUser(eq(expectedMemberId.getStringValue()), any());
         verify(keycloakUserService, times(1)).updateUser(any(), any());
 
         verify(keycloakGroupService, times(1)).getGroupByPath(eq(driveGroupPath));
         verify(keycloakGroupService, times(1)).getGroupByPath(eq(memberGroupPath));
         verify(keycloakGroupService, times(2)).getGroupByPath(any());
 
-        verify(keycloakUserService, times(1)).getGroups(eq(expectedMemberId.getValue()));
+        verify(keycloakUserService, times(1)).getGroups(eq(expectedMemberId.getStringValue()));
         verify(keycloakUserService, times(1)).getGroups(any());
 
         verify(keycloakUserService, times(0)).deleteGroup(any(), any());
 
-        verify(keycloakUserService, times(1)).addGroup(eq(expectedMemberId.getValue()), eq(driveGroupId));
+        verify(keycloakUserService, times(1)).addGroup(eq(expectedMemberId.getStringValue()), eq(driveGroupId));
         verify(keycloakUserService, times(1)).addGroup(any(), any());
 
         verify(memberJpaRepository, times(1)).save(any(MemberJpaEntity.class));
@@ -305,7 +307,7 @@ public class DefaultMemberGatewayTest {
     @Test
     void givenAValidMemberWithNoKeycloaksDataAltered_whenCallsUpdate_thenShouldUpdateMemberOwnDatabaseButNotInKeycloak() {
 
-        final var expectedMemberId = MemberID.of("123");
+        final var expectedMemberId = MemberID.of(UUID.randomUUID());
         final var expectedUserName = Username.of("username");
         final var expectedEmail = Email.of("user@member.com");
         final var expectedNickname = Nickname.of("new_nickname");


### PR DESCRIPTION
This pull request refactors the member ID handling across the application and domain layers to use `UUID` instead of `String`. This change improves type safety and consistency in member identification. It also updates related event, input/output, and test classes to support the new ID type, and ensures error messages correctly format UUIDs. The most important changes are grouped below.

### Member ID Type Refactoring

* Changed the `MemberID` class to use `UUID` instead of `String` for its value, with new factory methods to convert from `String` to `UUID` and updated `getStringValue()` implementation. (`domain/src/main/java/com/callv2/member/domain/member/entity/MemberID.java`)
* Updated all input and output records (such as `TogleMemberActivationInput`, `GetMemberInput`, `UpdateMemberSystemAccessInput`, `CreateMemberOutput`, `GetMemberOutput`, `MemberListOutput`) to use `UUID` for member IDs. (`application/src/main/java/com/callv2/member/application/member/activation/TogleMemberActivationInput.java`, `application/src/main/java/com/callv2/member/application/member/retrieve/get/GetMemberInput.java`, `application/src/main/java/com/callv2/member/application/member/update/system/UpdateMemberSystemAccessInput.java`, `application/src/main/java/com/callv2/member/application/member/create/CreateMemberOutput.java`, `application/src/main/java/com/callv2/member/application/member/retrieve/get/GetMemberOutput.java`, `application/src/main/java/com/callv2/member/application/member/retrieve/list/MemberListOutput.java`) [[1]](diffhunk://#diff-e3dd1551017904b4338ce71bf99540774791b1e99f1e3910e7cb59967470ee83L3-R7) [[2]](diffhunk://#diff-ea0afbf79db49a95e384a58cdb13a5bfdf236f7e207ec6cb1864c9f5cf636bd6L3-R7) [[3]](diffhunk://#diff-317bf997e126cb3c4c7c2a67d395cdc0d1e5a334e3a080fd60f1e39858f73ebdR4-R10) [[4]](diffhunk://#diff-ef71261b85e5a767fff897c3b9478a041e4432bc52f7f4942c5e184181cfee60L3-R7) [[5]](diffhunk://#diff-8fd20830089d40d70663a3b5ebbc013dbf2f2094b7f79b21ed5a7ee0f56dd151R5-R11) [[6]](diffhunk://#diff-54a3cf7530d7d959aad82566b01fcf4bca5f17a65e5c0513723dcac4edf3e599R4-R9)

### Event Data Structure Updates

* Updated member-related event data records (`MemberCreatedEvent.Data`, `MemberUpdatedEvent.Data`) to use `UUID` for IDs. (`domain/src/main/java/com/callv2/member/domain/member/event/MemberCreatedEvent.java`, `domain/src/main/java/com/callv2/member/domain/member/event/MemberUpdatedEvent.java`) [[1]](diffhunk://#diff-604fbbe8d2bc8897b315795c63595d3244c6e91a4c3285c4bc58ad798c807147L30-R31) [[2]](diffhunk://#diff-2a5b9fdd9a35c84c5656e63ea163019cdb6aa411281edeae0154f9f338a8095cL30-R31)

### Error Handling Improvements

* Modified exception throwing to use `UUID.toString()` in error messages for member not found scenarios, ensuring correct formatting. (`application/src/main/java/com/callv2/member/application/member/activation/DefaultTogleMemberActivationUseCase.java`, `application/src/main/java/com/callv2/member/application/member/retrieve/get/DefaultGetMemberUseCase.java`, `application/src/main/java/com/callv2/member/application/member/update/system/DefaultUpdateMemberSystemAccessUseCase.java`) [[1]](diffhunk://#diff-a48bb4dce5b6603435da787d9941c1e6d9fa7512016502ec0d429b882e0cdef2L29-R29) [[2]](diffhunk://#diff-0c7026a2af771338a21c0a1d04392b66c8f4f2435802037837a62b13109e72b7L23-R23) [[3]](diffhunk://#diff-e131e987d62fd0e4d5c25070d9480568ff2be71b7ca8f45494f3f4d0927a0426L29-R29)

### Test Updates

* Refactored all relevant tests to use `UUID.randomUUID()` for member IDs and updated expected error messages to format UUIDs. (`application/src/test/java/com/callv2/member/application/member/activation/DefaultTogleMemberActivationUseCaseTest.java`, `application/src/test/java/com/callv2/member/application/member/create/DefaultCreateMemberUseCaseTest.java`, `application/src/test/java/com/callv2/member/application/member/retrieve/get/DefaultGetMemberUseCaseTest.java`, `application/src/test/java/com/callv2/member/application/member/retrieve/list/DefaultListMembersUseCaseTest.java`, `application/src/test/java/com/callv2/member/application/member/update/system/DefaultUpdateMemberSystemAccessUseCaseTest.java`, `domain/src/test/java/com/callv2/member/domain/member/entity/MemberTest.java`) [[1]](diffhunk://#diff-48244e6e6b5d1d9232eada384a2b7d2616bed6877be90c7082952f87ad17c5a6L50-R51) [[2]](diffhunk://#diff-48244e6e6b5d1d9232eada384a2b7d2616bed6877be90c7082952f87ad17c5a6L116-R117) [[3]](diffhunk://#diff-48244e6e6b5d1d9232eada384a2b7d2616bed6877be90c7082952f87ad17c5a6L182-R190) [[4]](diffhunk://#diff-c90afca2cacab34f837d3ad1acd023e75d2fdc301cd36931933d2644384b09b3L65-R66) [[5]](diffhunk://#diff-d109e5aabee797db4361780570172d2ba79253e2de2029be2b568186594b8348L43-R44) [[6]](diffhunk://#diff-d109e5aabee797db4361780570172d2ba79253e2de2029be2b568186594b8348L86-R92) [[7]](diffhunk://#diff-583e220f87a7df734205e3cb50cf140f1d47b75a62f87a9857b35bff07b46b61L45-R46) [[8]](diffhunk://#diff-583e220f87a7df734205e3cb50cf140f1d47b75a62f87a9857b35bff07b46b61L56-R57) [[9]](diffhunk://#diff-1daffeb19b5143f4307ebd480b2e144de738d37e30ef658be48fb5f40951a95eL54-R55) [[10]](diffhunk://#diff-1daffeb19b5143f4307ebd480b2e144de738d37e30ef658be48fb5f40951a95eL115-R120) [[11]](diffhunk://#diff-a13007b4f06fb104e8292646e1df24a5653f60e4945112d3b7b52da9e78c67d9L25-R26)

### Dependency and Import Updates

* Added necessary imports for `UUID` throughout the codebase to support the new member ID type. [[1]](diffhunk://#diff-e3dd1551017904b4338ce71bf99540774791b1e99f1e3910e7cb59967470ee83L3-R7) [[2]](diffhunk://#diff-ea0afbf79db49a95e384a58cdb13a5bfdf236f7e207ec6cb1864c9f5cf636bd6L3-R7) [[3]](diffhunk://#diff-317bf997e126cb3c4c7c2a67d395cdc0d1e5a334e3a080fd60f1e39858f73ebdR4-R10) [[4]](diffhunk://#diff-ef71261b85e5a767fff897c3b9478a041e4432bc52f7f4942c5e184181cfee60L3-R7) [[5]](diffhunk://#diff-8fd20830089d40d70663a3b5ebbc013dbf2f2094b7f79b21ed5a7ee0f56dd151R5-R11) [[6]](diffhunk://#diff-54a3cf7530d7d959aad82566b01fcf4bca5f17a65e5c0513723dcac4edf3e599R4-R9) [[7]](diffhunk://#diff-604fbbe8d2bc8897b315795c63595d3244c6e91a4c3285c4bc58ad798c807147R6) [[8]](diffhunk://#diff-2a5b9fdd9a35c84c5656e63ea163019cdb6aa411281edeae0154f9f338a8095cR6) [[9]](diffhunk://#diff-48244e6e6b5d1d9232eada384a2b7d2616bed6877be90c7082952f87ad17c5a6R18) [[10]](diffhunk://#diff-c90afca2cacab34f837d3ad1acd023e75d2fdc301cd36931933d2644384b09b3R15) [[11]](diffhunk://#diff-d109e5aabee797db4361780570172d2ba79253e2de2029be2b568186594b8348R15) [[12]](diffhunk://#diff-583e220f87a7df734205e3cb50cf140f1d47b75a62f87a9857b35bff07b46b61R11) [[13]](diffhunk://#diff-1daffeb19b5143f4307ebd480b2e144de738d37e30ef658be48fb5f40951a95eR19) [[14]](diffhunk://#diff-a13007b4f06fb104e8292646e1df24a5653f60e4945112d3b7b52da9e78c67d9R10)

These changes ensure member IDs are consistently and safely handled as UUIDs throughout the application, domain, event, and test layers.